### PR TITLE
Emails sent in development mode are written to ./tmp/mails/, fixes #30, #31, #11, #21

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,4 +1,5 @@
 Autoadvisor::Application.configure do
+  config.action_mailer.delivery_method = :file
   # Settings specified here will take precedence over those in config/application.rb
   config.action_mailer.default_url_options = {
     :host => '127.0.0.1',


### PR DESCRIPTION
Not perfect for test environment (that's a separate deal altogether, but I looked into this and it's something we could do if we think it's worth the time). However, I think devise has a pretty good mailing system built in and I don't see any code of our own that needs testing.
